### PR TITLE
fix: temporarily disable identity module due to Azure AD permissions

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -128,6 +128,10 @@ module "communication" {
 }
 
 // Identity and security module (Azure AD app, SP, groups, secrets)
+// TEMPORARILY DISABLED: Requires Azure AD Application Administrator permissions
+// Service principal f187369a-7019-4e0e-a6e3-798a5f5e449b lacks directory-level permissions
+// Re-enable after assigning "Application Administrator" role to service principal
+/*
 module "identity" {
   source = "./modules/identity"
 
@@ -152,6 +156,7 @@ module "identity" {
 
   depends_on = [module.core]
 }
+*/
 
 // Automation module (Logic Apps, Service Bus, automation monitoring)
 module "automation" {

--- a/namespace-evidence.json
+++ b/namespace-evidence.json
@@ -1,0 +1,44 @@
+{
+  "extendedLocation": null,
+  "id": "/subscriptions/7db47e1f-79a2-4a18-9797-c803ca806c29/resourceGroups/csb-prod-rg/providers/Microsoft.NotificationHubs/namespaces/csb-prod-nh-ns-7ndjbzgu",
+  "identity": null,
+  "kind": null,
+  "location": "South Africa North",
+  "managedBy": null,
+  "name": "csb-prod-nh-ns-7ndjbzgu",
+  "plan": null,
+  "properties": {
+    "createdAt": "2025-08-19T17:46:28.23+00:00",
+    "critical": false,
+    "enabled": true,
+    "name": "csb-prod-nh-ns-7ndjbzgu",
+    "namespaceType": "NotificationHub",
+    "networkAcls": {},
+    "privateEndpointConnections": [],
+    "provisioningState": "Succeeded",
+    "publicNetworkAccess": "Enabled",
+    "serviceBusEndpoint": "https://csb-prod-nh-ns-7ndjbzgu.servicebus.windows.net:443/",
+    "status": "Created",
+    "subscriptionId": "7db47e1f-79a2-4a18-9797-c803ca806c29",
+    "updatedAt": "2025-08-19T17:46:28.25+00:00",
+    "zoneRedundancy": "Enabled"
+  },
+  "resourceGroup": "csb-prod-rg",
+  "sku": {
+    "capacity": null,
+    "family": null,
+    "model": null,
+    "name": "Free",
+    "size": null,
+    "tier": null
+  },
+  "tags": {
+    "CostCenter": "Education",
+    "Environment": "prod",
+    "ManagedBy": "terraform",
+    "Owner": "DevOps",
+    "Project": "csb",
+    "Purpose": "Production environment for campus study buddy application"
+  },
+  "type": "Microsoft.NotificationHubs/namespaces"
+}

--- a/notification-hub-evidence.json
+++ b/notification-hub-evidence.json
@@ -1,0 +1,17 @@
+{
+  "authorizationRules": [],
+  "id": "/subscriptions/7db47e1f-79a2-4a18-9797-c803ca806c29/resourceGroups/csb-prod-rg/providers/Microsoft.NotificationHubs/namespaces/csb-prod-nh-ns-7ndjbzgu/NotificationHubs/csb-prod-nh",
+  "location": "South Africa North",
+  "name": "csb-prod-nh",
+  "registrationTtl": "10675199.02:48:05.4775807",
+  "resourceGroup": "csb-prod-rg",
+  "tags": {
+    "CostCenter": "Education",
+    "Environment": "prod",
+    "ManagedBy": "terraform",
+    "Owner": "DevOps",
+    "Project": "csb",
+    "Purpose": "Production environment for campus study buddy application"
+  },
+  "type": "Microsoft.NotificationHubs/namespaces/notificationHubs"
+}

--- a/subscription-evidence.json
+++ b/subscription-evidence.json
@@ -1,0 +1,16 @@
+{
+  "environmentName": "AzureCloud",
+  "homeTenantId": "4b1b908c-5582-4377-ba07-a36d65e34934",
+  "id": "7db47e1f-79a2-4a18-9797-c803ca806c29",
+  "isDefault": true,
+  "managedByTenants": [],
+  "name": "Azure for Students",
+  "state": "Enabled",
+  "tenantDefaultDomain": "wits.ac.za",
+  "tenantDisplayName": "University of Witwatersrand",
+  "tenantId": "4b1b908c-5582-4377-ba07-a36d65e34934",
+  "user": {
+    "name": "684129@students.wits.ac.za",
+    "type": "user"
+  }
+}


### PR DESCRIPTION
## Problem
- Service principal lacks Azure AD Application Administrator permissions
- Infrastructure deployment fails when trying to create Azure AD applications
- GitHub Actions workflow cannot complete due to insufficient directory-level permissions

## Solution
- Temporarily comment out identity module that requires Azure AD permissions
- All other Azure infrastructure (networking, storage, compute, automation) can deploy successfully
- Service principal has all necessary Azure resource permissions for core infrastructure

## Changes
- Comment out `module.identity` in main.tf with detailed explanation
- Infrastructure can now deploy via GitHub Actions with service principal
- Orphaned Key Vault secrets from previous identity module will be cleaned up

## Next Steps
- [ ] Contact Azure AD administrator to assign 'Application Administrator' role to service principal `f187369a-7019-4e0e-a6e3-798a5f5e449b`
- [ ] Once permissions are granted, uncomment identity module
- [ ] Re-enable Azure AD integration for authentication

## Testing
- ✅ GitHub Actions workflow runs successfully
- ✅ Terraform plan shows clean infrastructure deployment
- ✅ All modules except identity deploy without errors

Fixes Azure AD permissions issue blocking infrastructure deployment.